### PR TITLE
Mol id fix

### DIFF
--- a/src/pyjess/_jess.pyx
+++ b/src/pyjess/_jess.pyx
@@ -2358,6 +2358,9 @@ cdef class Hit:
         if self._template.id is None:
             raise RuntimeError("cannot dump `Hit` where `self.template.id` is `None`")
 
+        if self._molecule.id is None:
+            raise RuntimeError("cannot dump `Hit` where `self.molecule.id` is `None`")
+
         file.write("REMARK ")
         file.write(self._molecule.id)
         file.write(f" {self.rmsd:5.3f} ")

--- a/src/pyjess/cli.py
+++ b/src/pyjess/cli.py
@@ -258,6 +258,9 @@ def main(
                 for filename in map(str.strip, f):
                     id_ = filename if args.query_filename else None
                     mol = Molecule.load(filename, id=id_, ignore_endmdl=args.ignore_endmdl)
+                    if mol.id is None:
+                        warnings.warn(f"No id in molecule {filename}. Using filename instead.")
+                        mol = Molecule(mol, id=filename, date=mol.date, name=mol.name)
                     if args.filenames:
                         print(filename, file=stderr)
                     query = jess.query(


### PR DESCRIPTION
Addressing issues when using PDB files from the AlphafoldDB which lack an ID in the Header:
- raises informative Error in Hit.dump
- avoids error in CLI by defaulting to using the filename as the id but raises warning.